### PR TITLE
Guarantee that labels are correctly aligned

### DIFF
--- a/confusion_matrix_pretty_print.py
+++ b/confusion_matrix_pretty_print.py
@@ -220,7 +220,7 @@ def plot_confusion_matrix_from_data(y_test, predictions, columns=None, annot=Tru
         from string import ascii_uppercase
         columns = ['class %s' %(i) for i in list(ascii_uppercase)[0:len(np.unique(y_test))]]
 
-    confm = confusion_matrix(y_test, predictions)
+    confm = confusion_matrix(y_test, predictions, labels=columns)
     cmap = 'Oranges';
     fz = 11;
     figsize=[9,9];


### PR DESCRIPTION
Minor addition of keyword argument 'labels' to calling scikit-learn's confusion_matrix will guarantee that classes are correctly aligned with the axes' labels.