### PR TITLE
Returning figure object to calling program

### DIFF
--- a/pretty_confusion_matrix/pretty_confusion_matrix.py
+++ b/pretty_confusion_matrix/pretty_confusion_matrix.py
@@ -240,6 +240,8 @@ def pp_matrix(
     plt.tight_layout()  # set layout slim
     plt.show()
 
+    return fig
+
 
 def pp_matrix_from_data(
     y_test,


### PR DESCRIPTION
It would be very helpful to get back the figure object created in the ``pp_matrix()`` function, e.g., for saving the figure or embedding it elsewhere using custom code. Therefore, I added the ``return fig`` statement in the aforementioned function. This will not change the default behavior of the function but increase its flexibility and usability.