### PR TITLE
Removed hard-coded values in pp_matrix_from_data

### DIFF
--- a/pretty_confusion_matrix/pretty_confusion_matrix.py
+++ b/pretty_confusion_matrix/pretty_confusion_matrix.py
@@ -272,9 +272,6 @@ def pp_matrix_from_data(
         ]
 
     confm = confusion_matrix(y_test, predictions)
-    fz = 11
-    figsize = [9, 9]
-    show_null_values = 2
     df_cm = DataFrame(confm, index=columns, columns=columns)
     pp_matrix(
         df_cm,


### PR DESCRIPTION
This PR removes hard-coded values from `pp_matrix_from_data`, which were perhaps left in as artifacts from a previous version. Please let me know if this is not the case.